### PR TITLE
No longer using VesselResourcesField for last stage resources.

### DIFF
--- a/AlternateResourcePanel/API/ARPWrapper.cs
+++ b/AlternateResourcePanel/API/ARPWrapper.cs
@@ -136,7 +136,7 @@ namespace ARPWrapper
                 
                 LogFormatted("Getting Last Stage Resources Object");
                 LastStageResourcesField = KSPARPType.GetField("lstResourcesLastStage", BindingFlags.Public | BindingFlags.Instance);
-                actualLastStageResources = VesselResourcesField.GetValue(actualARP);
+                actualLastStageResources = LastStageResourcesField.GetValue(actualARP);
                 LogFormatted("Success: " + (actualLastStageResources != null).ToString());
 
                 LogFormatted("Getting State Change Event");


### PR DESCRIPTION
Hey hey.
Quick PR to fix a bug in the API wrapper, where the vessel resources are accidentally in place of the last stage resources.

Thanks for a nice plugin. :)