### PR TITLE
Fix duplicated ressources

### DIFF
--- a/AlternateResourcePanel/ARP.cs
+++ b/AlternateResourcePanel/ARP.cs
@@ -293,19 +293,19 @@ namespace KSPAlternateResourcePanel
             if (settings.Resources.Count == 0) {
                 // Set a Default config
                 LogFormatted("Setting a Default Res Config");
-                settings.Resources.Add(1576437329, new ResourceSettings(1576437329, "ElectricCharge"));
-                settings.Resources.Add(2001413032, new ResourceSettings(2001413032, "MonoPropellant"));
-                settings.Resources.Add(-792463147, new ResourceSettings(-792463147, "EVA Propellant"));
+                settings.Resources.Add(1566956177, new ResourceSettings(1566956177, "ElectricCharge"));
+                settings.Resources.Add(-929029996, new ResourceSettings(-929029996, "MonoPropellant"));
+                settings.Resources.Add(-1511737247, new ResourceSettings(-1511737247, "EVA Propellant"));
                 settings.Resources.Add(34, new ResourceSettings(34, "") { IsSeparator = true });
-                settings.Resources.Add(466598945, new ResourceSettings(466598945, "Ablator"));
+                settings.Resources.Add(-637467525, new ResourceSettings(-637467525, "Ablator"));
                 settings.Resources.Add(35, new ResourceSettings(35, "") { IsSeparator = true });
-                settings.Resources.Add(374119730, new ResourceSettings(374119730, "LiquidFuel"));
-                settings.Resources.Add(-1823983486, new ResourceSettings(-1823983486, "Oxidizer"));
-                settings.Resources.Add(650317537, new ResourceSettings(650317537, "SolidFuel"));
+                settings.Resources.Add(-1483389306, new ResourceSettings(-1483389306, "LiquidFuel"));
+                settings.Resources.Add(-1154601244, new ResourceSettings(-1154601244, "Oxidizer"));
+                settings.Resources.Add(-234914041, new ResourceSettings(-234914041, "SolidFuel"));
                 settings.Resources.Add(36, new ResourceSettings(36, "") { IsSeparator = true });
-                settings.Resources.Add(-1909417378, new ResourceSettings(-1909417378, "IntakeAir"));
-                settings.Resources.Add(79554, new ResourceSettings(79554, "Ore"));
-                settings.Resources.Add(1447111193, new ResourceSettings(1447111193, "XenonGas"));
+                settings.Resources.Add(1669081118, new ResourceSettings(1669081118, "IntakeAir"));
+                settings.Resources.Add(386854434, new ResourceSettings(386854434, "Ore"));
+                settings.Resources.Add(-798680445, new ResourceSettings(-798680445, "XenonGas"));
             }
 
             foreach (PartResourceDefinition item in PartResourceLibrary.Instance.resourceDefinitions)


### PR DESCRIPTION
When there is no configuration file, it is created with a default resource list. However the ids of these resources don't correspond with those present in the game (breaking change?). In the configuration window, resources appeared in duplicate.

As you can see in the screenshot: [Screen shot](https://i.imgur.com/DIFW2Hk.png)

So I updated the old ids.